### PR TITLE
Add change tracking based on object references

### DIFF
--- a/src/TalisOrm/Aggregate.php
+++ b/src/TalisOrm/Aggregate.php
@@ -58,13 +58,6 @@ interface Aggregate extends Entity
     public static function fromState(array $aggregateState, array $childEntitiesByType);
 
     /**
-     * Return any deleted child entities.
-     *
-     * @return ChildEntity[]
-     */
-    public function deletedChildEntities();
-
-    /**
      * Return domain events that have been recorded internally, and immediately forget about them. That is: a second
      * call to this method would return an empty array.
      *

--- a/src/TalisOrm/Aggregate.php
+++ b/src/TalisOrm/Aggregate.php
@@ -38,7 +38,7 @@ interface Aggregate extends Entity
      * Recreate the root entity, based on the state that was retrieved from the database. This can be expected to be
      * equivalent to the state that was earlier returned by `Aggregate::getState()`. Sample implementation:
      *
-     * public static function fromState(array $aggregateState, array $childEntityStatesByType): Aggregate
+     * public static function fromState(array $aggregateState, array $childEntitiesByType): Aggregate
      * {
      *     list($orderState, $lineStates) = $states;
      *
@@ -46,18 +46,16 @@ interface Aggregate extends Entity
      *     $order->orderId = new OrderId($aggregateState['order_id']);
      *     // ...
      *
-     *     $order->lines = [];
-     *     foreach ($childEntityStatesByType[Line::class] as $lineState) {
-     *         $line = Line::fromState($lineState);
-     *         $order->lines[] = $line;
-     *     }
+     *     $order->lines = $childEntitiesByType[Line::class];
+     *
+     *     return $order;
      * }
      *
      * @param array $aggregateState
-     * @param array $childEntityStatesByType
+     * @param array $childEntitiesByType
      * @return static
      */
-    public static function fromState(array $aggregateState, array $childEntityStatesByType);
+    public static function fromState(array $aggregateState, array $childEntitiesByType);
 
     /**
      * Return any deleted child entities.

--- a/src/TalisOrm/AggregateRepository.php
+++ b/src/TalisOrm/AggregateRepository.php
@@ -177,6 +177,8 @@ final class AggregateRepository
                     );
                 }
             }
+
+            $this->forgetAggregate($aggregate);
         });
     }
 
@@ -294,5 +296,13 @@ final class AggregateRepository
                 $this->rememberEntity($childEntity);
             }
         }
+    }
+
+    private function forgetAggregate(Aggregate $aggregate)
+    {
+        unset(
+            $this->knownEntities[spl_object_hash($aggregate)],
+            $this->knownChildEntities[spl_object_hash($aggregate)]
+        );
     }
 }

--- a/test/TalisOrm/AbstractAggregateRepositoryTest.php
+++ b/test/TalisOrm/AbstractAggregateRepositoryTest.php
@@ -288,7 +288,7 @@ abstract class AbstractAggregateRepositoryTest extends TestCase
         $aggregate = $this->repository->getById($aggregate->orderId());
 
         $aggregate->updateLine(
-            new LineNumber(2),
+            new LineNumber(1),
             new ProductId('ec739f60-0d09-47f5-ae42-e2157ba709e2', 5),
             new Quantity(7)
         );

--- a/test/TalisOrm/AbstractAggregateRepositoryTest.php
+++ b/test/TalisOrm/AbstractAggregateRepositoryTest.php
@@ -272,6 +272,36 @@ abstract class AbstractAggregateRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function it_updates_child_entities_after_the_aggregate_was_refreshed()
+    {
+        $aggregate = Order::create(
+            new OrderId('91338a57-5c9a-40e8-b5e8-803e8175c7d7', 5),
+            DateTimeUtil::createDateTimeImmutable('2018-10-03')
+        );
+        $aggregate->addLine(
+            new LineNumber(1),
+            new ProductId('73d46c97-a71b-4e3c-9633-bb7a8603b301', 5),
+            new Quantity(10)
+        );
+        $this->repository->save($aggregate);
+
+        $aggregate = $this->repository->getById($aggregate->orderId());
+
+        $aggregate->updateLine(
+            new LineNumber(2),
+            new ProductId('ec739f60-0d09-47f5-ae42-e2157ba709e2', 5),
+            new Quantity(7)
+        );
+        $this->repository->save($aggregate);
+
+        $fromDatabase = $this->repository->getById($aggregate->orderId());
+
+        self::assertEquals($aggregate, $fromDatabase);
+    }
+
+    /**
+     * @test
+     */
     public function it_deletes_child_entities_that_have_been_removed_from_the_aggregate()
     {
         $aggregate = Order::create(

--- a/test/TalisOrm/AbstractAggregateRepositoryTest.php
+++ b/test/TalisOrm/AbstractAggregateRepositoryTest.php
@@ -362,6 +362,26 @@ abstract class AbstractAggregateRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function saving_a_deleted_aggregate_will_recreate_it()
+    {
+        $aggregate = Order::create(
+            new OrderId('91338a57-5c9a-40e8-b5e8-803e8175c7d7', 5),
+            DateTimeUtil::createDateTimeImmutable('2018-10-03')
+        );
+        $this->repository->save($aggregate);
+
+        $this->repository->delete($aggregate);
+
+        $this->repository->save($aggregate);
+
+        $fromDatabase = $this->repository->getById($aggregate->orderId());
+
+        self::assertEquals($aggregate, $fromDatabase);
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_delete_all_aggregates_of_the_same_type()
     {
         $aggregate1 = Order::create(

--- a/test/TalisOrm/AggregateRepositoryTest/FromStateDoesNotReturnAnAggregate.php
+++ b/test/TalisOrm/AggregateRepositoryTest/FromStateDoesNotReturnAnAggregate.php
@@ -69,11 +69,6 @@ final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSch
         ];
     }
 
-    public function deletedChildEntities()
-    {
-        return [];
-    }
-
     public static function specifySchema(Schema $schema)
     {
         $table = $schema->createTable('from_state_does_not_return_an_aggregate');

--- a/test/TalisOrm/AggregateRepositoryTest/Order.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Order.php
@@ -153,7 +153,7 @@ final class Order implements Aggregate, SpecifiesSchema
         ];
     }
 
-    public static function fromState(array $aggregateState, array $childEntityStatesByType)
+    public static function fromState(array $aggregateState, array $childEntitiesByType)
     {
         $order = new self();
 
@@ -165,12 +165,7 @@ final class Order implements Aggregate, SpecifiesSchema
         }
         $order->orderDate = $dateTimeImmutable;
 
-        $order->lines = [];
-        foreach ($childEntityStatesByType[Line::class] as $lineState) {
-            $entity = Line::fromState($lineState);
-            Assert::isInstanceOf($entity, Line::class);
-            $order->lines[] = $entity;
-        }
+        $order->lines = $childEntitiesByType[Line::class];
 
         $order->aggregateVersion = (int)$aggregateState[Aggregate::VERSION_COLUMN];
 

--- a/test/TalisOrm/AggregateRepositoryTest/Order.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Order.php
@@ -32,11 +32,6 @@ final class Order implements Aggregate, SpecifiesSchema
     private $lines = [];
 
     /**
-     * @var array
-     */
-    private $deletedChildEntities = [];
-
-    /**
      * @var int
      */
     private $aggregateVersion;
@@ -112,7 +107,6 @@ final class Order implements Aggregate, SpecifiesSchema
         foreach ($this->lines as $index => $line) {
             if ($line->lineNumber()->asInt() === $lineId->asInt()) {
                 unset($this->lines[$index]);
-                $this->deleteChildEntity($line);
             }
         }
 
@@ -194,20 +188,6 @@ final class Order implements Aggregate, SpecifiesSchema
             'order_id' => $aggregateId->orderId(),
             'company_id' => $aggregateId->companyId()
         ];
-    }
-
-    public function deletedChildEntities()
-    {
-        $deletedChildEntities = $this->deletedChildEntities;
-
-        $this->deletedChildEntities = [];
-
-        return $deletedChildEntities;
-    }
-
-    private function deleteChildEntity(ChildEntity $childEntity)
-    {
-        $this->deletedChildEntities[] = $childEntity;
     }
 
     public static function specifySchema(Schema $schema)

--- a/test/TalisOrm/AggregateRepositoryTest/Order.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Order.php
@@ -6,7 +6,6 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Schema\Schema;
 use TalisOrm\Aggregate;
 use TalisOrm\AggregateId;
-use TalisOrm\ChildEntity;
 use TalisOrm\DateTimeUtil;
 use TalisOrm\DomainEvents\EventRecordingCapabilities;
 use TalisOrm\Schema\SpecifiesSchema;

--- a/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregate.php
+++ b/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregate.php
@@ -67,11 +67,6 @@ final class SimpleAggregate implements Aggregate, SpecifiesSchema
         ];
     }
 
-    public function deletedChildEntities()
-    {
-        return [];
-    }
-
     public static function specifySchema(Schema $schema)
     {
         $table = $schema->createTable('simple_aggregate');

--- a/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregate.php
+++ b/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregate.php
@@ -1,25 +1,24 @@
 <?php
 
-namespace TalisOrm\AggregateRepositoryTest;
+namespace TalisOrm\AggregateRepositoryTest\SimpleAggregate;
 
 use Doctrine\DBAL\Schema\Schema;
-use stdClass;
 use TalisOrm\Aggregate;
 use TalisOrm\AggregateId;
 use TalisOrm\DomainEvents\EventRecordingCapabilities;
 use TalisOrm\Schema\SpecifiesSchema;
 use Webmozart\Assert\Assert;
 
-final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSchema
+final class SimpleAggregate implements Aggregate, SpecifiesSchema
 {
     use EventRecordingCapabilities;
 
     /**
-     * @var FromStateDoesNotReturnAnAggregateId
+     * @var SimpleAggregateId
      */
     private $aggregateId;
 
-    public function __construct(FromStateDoesNotReturnAnAggregateId $aggregateId)
+    public function __construct(SimpleAggregateId $aggregateId)
     {
         $this->aggregateId = $aggregateId;
     }
@@ -43,13 +42,12 @@ final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSch
 
     public static function fromState(array $aggregateState, array $childEntitiesByType)
     {
-        // Note: not an instance of this aggregate class
-        return new stdClass();
+        return new self(new SimpleAggregateId($aggregateState['aggregate_id']));
     }
 
     public static function tableName()
     {
-        return 'from_state_does_not_return_an_aggregate';
+        return 'simple_aggregate';
     }
 
     public function identifier()
@@ -61,8 +59,8 @@ final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSch
 
     public static function identifierForQuery(AggregateId $aggregateId)
     {
-        Assert::isInstanceOf($aggregateId, FromStateDoesNotReturnAnAggregateId::class);
-        /** @var FromStateDoesNotReturnAnAggregateId $aggregateId */
+        Assert::isInstanceOf($aggregateId, SimpleAggregateId::class);
+        /** @var SimpleAggregateId $aggregateId */
 
         return [
             'aggregate_id' => $aggregateId->id()
@@ -76,8 +74,8 @@ final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSch
 
     public static function specifySchema(Schema $schema)
     {
-        $table = $schema->createTable('from_state_does_not_return_an_aggregate');
+        $table = $schema->createTable('simple_aggregate');
         $table->addColumn('aggregate_id', 'integer');
-        $table->addUniqueIndex(['aggregate_id']);
+        $table->setPrimaryKey(['aggregate_id']);
     }
 }

--- a/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregateId.php
+++ b/test/TalisOrm/AggregateRepositoryTest/SimpleAggregate/SimpleAggregateId.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TalisOrm\AggregateRepositoryTest\SimpleAggregate;
+
+use TalisOrm\AggregateId;
+use Webmozart\Assert\Assert;
+
+final class SimpleAggregateId implements AggregateId
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    public function __construct($id)
+    {
+        Assert::integer($id);
+        $this->id = $id;
+    }
+
+    public function __toString()
+    {
+        return (string)$this->id;
+    }
+
+    public function id()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
1. Dealing with deleted child entities

This includes a change in the signature of `Aggregate::fromState()`, which now retrieves an array of actual child entities instead of just their states.

The user doesn't have to implement their own `deletedChildEntities()` method anymore, in fact, they don't have to track deleted child entities at all.

2. Dealing with concurrent inserts

To prevent people from creating two aggregates with the same ID, we shouldn't use the identifier to determine if an update or insert is required. Instead, we should check if the aggregate is new (or "known") and update or insert based on that information.