### PR TITLE
Change tracking, take 2

### DIFF
--- a/src/TalisOrm/Aggregate.php
+++ b/src/TalisOrm/Aggregate.php
@@ -38,7 +38,7 @@ interface Aggregate extends Entity
      * Recreate the root entity, based on the state that was retrieved from the database. This can be expected to be
      * equivalent to the state that was earlier returned by `Aggregate::getState()`. Sample implementation:
      *
-     * public static function fromState(array $aggregateState, array $childEntityStatesByType): Aggregate
+     * public static function fromState(array $aggregateState, array $childEntitiesByType): Aggregate
      * {
      *     list($orderState, $lineStates) = $states;
      *
@@ -46,18 +46,16 @@ interface Aggregate extends Entity
      *     $order->orderId = new OrderId($aggregateState['order_id']);
      *     // ...
      *
-     *     $order->lines = [];
-     *     foreach ($childEntityStatesByType[Line::class] as $lineState) {
-     *         $line = Line::fromState($lineState);
-     *         $order->lines[] = $line;
-     *     }
+     *     $order->lines = $childEntitiesByType[Line::class];
+     *
+     *     return $order;
      * }
      *
      * @param array $aggregateState
-     * @param array $childEntityStatesByType
+     * @param array $childEntitiesByType
      * @return static
      */
-    public static function fromState(array $aggregateState, array $childEntityStatesByType);
+    public static function fromState(array $aggregateState, array $childEntitiesByType);
 
     /**
      * Return any deleted child entities.

--- a/src/TalisOrm/AggregateRepository.php
+++ b/src/TalisOrm/AggregateRepository.php
@@ -159,7 +159,12 @@ final class AggregateRepository
 
     private function insertOrUpdate(Entity $entity)
     {
-        if ($this->exists($entity::tableName(), $entity->identifier())) {
+        if ($entity->isNew()) {
+            $this->connection->insert(
+                $this->connection->quoteIdentifier($entity::tableName()),
+                $entity->state()
+            );
+        } else {
             $state = $entity->state();
             if (array_key_exists(Aggregate::VERSION_COLUMN, $state)) {
                 $aggregateVersion = $state[Aggregate::VERSION_COLUMN];
@@ -177,26 +182,7 @@ final class AggregateRepository
                 $state,
                 $entity->identifier()
             );
-        } else {
-            $this->connection->insert(
-                $this->connection->quoteIdentifier($entity::tableName()),
-                $entity->state()
-            );
         }
-    }
-
-    /**
-     * @param string $tableName
-     * @param array $identifier
-     * @return bool
-     */
-    private function exists($tableName, array $identifier)
-    {
-        Assert::string($tableName);
-
-        $count = $this->select('COUNT(*)', $tableName, $identifier)->fetchColumn();
-
-        return (int)$count > 0;
     }
 
     /**

--- a/src/TalisOrm/Entity.php
+++ b/src/TalisOrm/Entity.php
@@ -54,4 +54,12 @@ interface Entity
      * @return array
      */
     public static function identifierForQuery(AggregateId $aggregateId);
+
+    /**
+     * Return a boolean indicating whether or not this entity is new, i.e. requires an INSERT statement to be used
+     * when saving it.
+     *
+     * @return bool
+     */
+    public function isNew();
 }

--- a/test/TalisOrm/AggregateRepositoryTest/FromStateDoesNotReturnAnAggregate.php
+++ b/test/TalisOrm/AggregateRepositoryTest/FromStateDoesNotReturnAnAggregate.php
@@ -80,4 +80,9 @@ final class FromStateDoesNotReturnAnAggregate implements Aggregate, SpecifiesSch
         $table->addColumn('aggregate_id', 'integer');
         $table->addUniqueIndex(['aggregate_id']);
     }
+
+    public function isNew()
+    {
+        return true;
+    }
 }

--- a/test/TalisOrm/AggregateRepositoryTest/Line.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Line.php
@@ -29,6 +29,11 @@ final class Line implements ChildEntity, SpecifiesSchema
      */
     private $quantity;
 
+    /**
+     * @var bool
+     */
+    private $isNew = true;
+
     private function __construct()
     {
     }
@@ -101,6 +106,8 @@ final class Line implements ChildEntity, SpecifiesSchema
 
     public function state()
     {
+        $this->isNew = false;
+
         return [
             'order_id' => $this->orderId->orderId(),
             'company_id' => $this->orderId->companyId(),
@@ -113,6 +120,7 @@ final class Line implements ChildEntity, SpecifiesSchema
     public static function fromState(array $state)
     {
         $line = new self();
+        $line->isNew = false;
 
         $line->orderId = new OrderId($state['order_id'], (int)$state['company_id']);
         $line->lineNumber = new LineNumber((int)$state['line_number']);
@@ -157,5 +165,10 @@ final class Line implements ChildEntity, SpecifiesSchema
         $table->addColumn('product_id', 'string');
         $table->addColumn('quantity', 'integer');
         $table->setPrimaryKey(['order_id', 'company_id', 'line_number']);
+    }
+
+    public function isNew()
+    {
+        return $this->isNew;
     }
 }

--- a/test/TalisOrm/AggregateRepositoryTest/Order.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Order.php
@@ -159,7 +159,7 @@ final class Order implements Aggregate, SpecifiesSchema
         ];
     }
 
-    public static function fromState(array $aggregateState, array $childEntityStatesByType)
+    public static function fromState(array $aggregateState, array $childEntitiesByType)
     {
         $order = new self();
         $order->isNew = false;
@@ -172,12 +172,7 @@ final class Order implements Aggregate, SpecifiesSchema
         }
         $order->orderDate = $dateTimeImmutable;
 
-        $order->lines = [];
-        foreach ($childEntityStatesByType[Line::class] as $lineState) {
-            $entity = Line::fromState($lineState);
-            Assert::isInstanceOf($entity, Line::class);
-            $order->lines[] = $entity;
-        }
+        $order->lines = $childEntitiesByType[Line::class];
 
         $order->aggregateVersion = (int)$aggregateState[Aggregate::VERSION_COLUMN];
 

--- a/test/TalisOrm/AggregateRepositoryTest/Order.php
+++ b/test/TalisOrm/AggregateRepositoryTest/Order.php
@@ -37,6 +37,11 @@ final class Order implements Aggregate, SpecifiesSchema
     private $deletedChildEntities = [];
 
     /**
+     * @var bool
+     */
+    private $isNew = true;
+
+    /**
      * @var int
      */
     private $aggregateVersion;
@@ -143,6 +148,7 @@ final class Order implements Aggregate, SpecifiesSchema
 
     public function state()
     {
+        $this->isNew = false;
         $this->aggregateVersion++;
 
         return [
@@ -156,6 +162,7 @@ final class Order implements Aggregate, SpecifiesSchema
     public static function fromState(array $aggregateState, array $childEntityStatesByType)
     {
         $order = new self();
+        $order->isNew = false;
 
         $order->orderId = new OrderId($aggregateState['order_id'], (int)$aggregateState['company_id']);
         $dateTimeImmutable = DateTimeUtil::createDateTimeImmutable($aggregateState['order_date']);
@@ -225,6 +232,11 @@ final class Order implements Aggregate, SpecifiesSchema
         $table->setPrimaryKey(['order_id', 'company_id']);
 
         Line::specifySchema($schema);
+    }
+
+    public function isNew()
+    {
+        return $this->isNew;
     }
 
     /**


### PR DESCRIPTION
This PR changes two things:

- All entities (aggregate roots and child entities) need to tell the repository if they are "new" or not, based on which the repository decides to issue an `INSERT` or an `UPDATE` query.
- When calling `Aggregate::fromState()`, the aggregate retrieves an array of instantiates child entities instead of state arrays. This is somewhat unrelated, but I thought it would be a useful part of the change that I introduced in #20.

Also, this removes the `exists()` method completely (@rpkamp will be happy!).

Finally, let me point out some nice properties of this library:

- We don't keep track of object references, meaning we don't run into `spl_object_hash()` collisions, as pointed out by @docteurklein).
- Users can make their aggregates immutable if they want, create copies of them, and save them again. They only need to provide the right answer when the repository calls `isNew()`.

Downside is: a bit more boilerplate code is required by the implementer (`isNew()` and an internal boolean flag, also, `state()` and `fromState()` should toggle that flag).

In another PR we might introduce a trait to help the implementer with this (same for optimistic concurrency locking). Don't know how useful that will be though.